### PR TITLE
fix_percyOptions_caps

### DIFF
--- a/wd/android.js
+++ b/wd/android.js
@@ -16,7 +16,7 @@ const desiredCaps = {
   },
 
   // Percy Options (defaults)
-  'appium:percyOptions': {
+  'percyOptions': {
     enabled: true,
     ignoreErrors: true
   },

--- a/wd/ios.js
+++ b/wd/ios.js
@@ -16,7 +16,7 @@ const desiredCaps = {
   },
 
   // Percy Options (defaults)
-  'appium:percyOptions': {
+  'percyOptions': {
     enabled: true,
     ignoreErrors: true
   },


### PR DESCRIPTION
Fixing percyOptions key, running with appium:percyOptions doesn’t read the value.