### PR TITLE
Added Percy CLI as dependency

### DIFF
--- a/manual/package.json
+++ b/manual/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "@percy/appium-app": "^0.0.5",
+    "@percy/cli": "^1.29.1",
     "filereader": "^0.10.3"
   }
 }


### PR DESCRIPTION
Running it without this would lead to :
```
Heads up! It looks like @percy/cli is not installed!

This usually happens when your package manager cannot find the 'percy' command
in your project, which may then cause it to download and use the wrong package.

Please make sure that @percy/cli is properly installed or provide the package
name to your package manager when running.```