### PR TITLE
Updated iphone 12 pro OS version

### DIFF
--- a/wd/ios.js
+++ b/wd/ios.js
@@ -25,7 +25,7 @@ const desiredCaps = {
 
   // Specify device and os_version for testing
   device: 'iPhone 12 Pro',
-  os_version: '16',
+  os_version: '17',
 
   // Set other BrowserStack capabilities
   project: 'First Node App Percy Project',

--- a/webdriverio/ios/ios.conf.js
+++ b/webdriverio/ios/ios.conf.js
@@ -13,7 +13,7 @@ exports.config = {
     build: 'App Percy Webdriverio iOS',
     name: 'first_visual_test',
     device: 'iPhone 12 Pro',
-    os_version: "16",
+    os_version: "17",
     app: process.env.APP || 'bs://<hashed app-id>'
   }],
 


### PR DESCRIPTION
Ticket - https://browserstack.atlassian.net/browse/PER-5604 
iphone 12 pro with os version 16 is throwing unsupported error. Updated os version from 16 to 17
<img width="857" height="90" alt="Screenshot 2025-09-01 at 3 44 41 PM" src="https://github.com/user-attachments/assets/9d58104d-9157-45a2-9826-954a590e764c" />
