### PR TITLE
fix(PER-8223): bump App Percy smoke device to Pixel 8 / Android 14

### DIFF
--- a/wd/android/smoke_test.js
+++ b/wd/android/smoke_test.js
@@ -25,8 +25,8 @@ const desiredCaps = {
   app: process.env.APP_URL,
 
   // Specify device and os_version for testing
-  device: 'Google Pixel 6 Pro',
-  os_version: '13',
+  device: 'Google Pixel 8',
+  os_version: '14',
 
   // Set other BrowserStack capabilities
   project: 'POA App Percy',


### PR DESCRIPTION
## What
Bumps the Android device cap in `wd/android/smoke_test.js` from **Google Pixel 6 Pro / Android 13** → **Google Pixel 8 / Android 14**.

## Why
The App Percy smoke (`app-percy-smoke-test`) authenticates and uploads the app fine, but the Appium **device session fails to start**:
```
Error: [quit()] Error response status: 13, UnknownError ... Session not started or terminated
```
→ no snapshots → build finalizes `failure-reason: no_snapshots` → failed. A common cause is the requested device/OS combo no longer being available on BrowserStack. Bumping to a newer, available device restores session startup.

## Base branch
Targets `regression_branch` because that's the branch the smoke pipeline checks out (`EXAMPLE_REPO_SDK_BRANCH_NAME=regression_branch`).

## Note
Separately, the App Percy smoke is currently also blocked by a Buildkite agent docker error (`max depth exceeded`, exit 17) that prevents the container build from completing — needs agent docker-layer cleanup. This PR only addresses the device-session (`status 13`) issue.

Part of PER-8223 (post-canary smoke for POA & App Percy). POA is already green + wired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)