### PR TITLE
fix(PER-8223): Android smoke takes home-screen snapshot (stale locator)

### DIFF
--- a/wd/android/smoke_test.js
+++ b/wd/android/smoke_test.js
@@ -54,14 +54,10 @@ driver.init(desiredCaps)
   // .then(function() {
   //   return percyScreenshot(driver, 'History tab');
   // })
-  .then(function () {
-    return driver.waitForElementByAccessibilityId('My lists', asserters.isDisplayed && asserters.isEnabled, 50000);
-  })
-  .then(function (searchElement) {
-    return searchElement.click();
-  })
   .then(function() {
-    return percyScreenshot(driver, 'Lists tab');
+    // Smoke test: capture the home screen once the app has loaded.
+    // (Previously waited for a 'My lists' element that no longer exists in the sample app.)
+    return percyScreenshot(driver, 'App Percy Smoke - Home');
   })
   .fin(function() {
     // Invoke driver.quit() after the test is done to indicate that the test is completed.


### PR DESCRIPTION
## What
The Android smoke (`wd/android/smoke_test.js`) now takes a Percy screenshot of the **home screen right after the app loads**, instead of waiting for an accessibility id `'My lists'` that no longer exists in the current Wikipedia sample app.

## Why
With the device session now starting (after the Pixel 8/14 bump), the smoke still failed because:
```
waitForElementByAccessibilityId("My lists", ...) Element condition wasn't satisfied!
```
→ `percyScreenshot` was never called → build finalized `failure-reason: no_snapshots` → failed. A home-screen snapshot is sufficient for a smoke (validates session → snapshot → build → finalize) and isn't tied to a fragile UI locator.

## Verified
Ran end-to-end **locally** (per team suggestion) — green:
```
[percy] Percy has started!
[percy] Snapshot taken: App Percy Smoke - Home
[percy] Finalized build #7873: https://percy.io/test/app/app-smoke-test-android/builds/50461869
[percy] Command "node android/smoke_test.js" exited with status: 0
```
Session started on Google Pixel 8 / Android 14, snapshot captured, build finalized, exit 0.

## Base branch
Targets `regression_branch` (the branch the smoke pipeline checks out).

Part of PER-8223. Pairs with the device bump (#18, merged). The remaining Buildkite-side blocker is the agent `max depth exceeded` docker error (infra cleanup) — unrelated to this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)