### PR TITLE
feat(PER-8195): iOS build scaffolding for advanced App Percy example

### DIFF
--- a/.github/workflows/advanced.yml
+++ b/.github/workflows/advanced.yml
@@ -15,6 +15,14 @@ on:
         options:
           - webdriverio
           - wd
+      platform:
+        description: 'Which platform to run against (android or ios)'
+        required: true
+        default: 'android'
+        type: choice
+        options:
+          - android
+          - ios
 
 permissions:
   contents: read
@@ -31,30 +39,37 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
+      # The App Automate app differs per platform: APP_BS_URL is the Android
+      # build, APP_BS_URL_IOS is the iOS build. Device/os defaults are resolved
+      # per-platform inside the advanced config via the PLATFORM env var.
       - name: Sanity-check required secrets
         env:
           AA_USERNAME: ${{ secrets.AA_USERNAME }}
           AA_ACCESS_KEY: ${{ secrets.AA_ACCESS_KEY }}
-          APP_BS_URL: ${{ secrets.APP_BS_URL }}
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
+          PLATFORM: ${{ inputs.platform }}
+          APP: ${{ inputs.platform == 'ios' && secrets.APP_BS_URL_IOS || secrets.APP_BS_URL }}
+          APP_SECRET_NAME: ${{ inputs.platform == 'ios' && 'APP_BS_URL_IOS' || 'APP_BS_URL' }}
         run: |
           missing=()
           [ -z "$AA_USERNAME" ]    && missing+=(AA_USERNAME)
           [ -z "$AA_ACCESS_KEY" ]  && missing+=(AA_ACCESS_KEY)
-          [ -z "$APP_BS_URL" ]     && missing+=(APP_BS_URL)
           [ -z "$PERCY_TOKEN" ]    && missing+=(PERCY_TOKEN)
+          [ -z "$APP" ]            && missing+=("$APP_SECRET_NAME")
           if [ ${#missing[@]} -gt 0 ]; then
-            echo "::error::Missing required repo secrets: ${missing[*]}"
+            echo "::error::Missing required repo secrets for platform '${PLATFORM}': ${missing[*]}"
             exit 1
           fi
       - name: Install advanced/ dependencies
         run: npm install
-      - name: Run wdio advanced tests against BrowserStack App Automate
+      - name: Run ${{ inputs.driver }} advanced tests against BrowserStack App Automate (${{ inputs.platform }})
         env:
           AA_USERNAME: ${{ secrets.AA_USERNAME }}
           AA_ACCESS_KEY: ${{ secrets.AA_ACCESS_KEY }}
-          APP: ${{ secrets.APP_BS_URL }}
+          # iOS uses APP_BS_URL_IOS, Android uses APP_BS_URL.
+          APP: ${{ inputs.platform == 'ios' && secrets.APP_BS_URL_IOS || secrets.APP_BS_URL }}
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
+          PLATFORM: ${{ inputs.platform }}
           PERCY_BRANCH: ${{ github.ref_name }}
           PERCY_COMMIT: ${{ github.sha }}
         run: npx --no-install percy app:exec -- npm run test:advanced

--- a/wd/advanced/advanced.js
+++ b/wd/advanced/advanced.js
@@ -8,17 +8,22 @@
 const percyScreenshot = require('@percy/appium-app')
 const wd = require('wd')
 
+// PLATFORM selects the device/os defaults (android | ios). The CI workflow
+// sets it and supplies the matching APP (Android: APP_BS_URL, iOS:
+// APP_BS_URL_IOS). DEVICE / OS_VERSION env vars still override per-run.
+const isIOS = (process.env.PLATFORM || 'android').toLowerCase() === 'ios'
+
 const desiredCaps = {
   'bstack:options': {
     userName: process.env.AA_USERNAME,
     accessKey: process.env.AA_ACCESS_KEY,
     projectName: process.env.BROWSERSTACK_PROJECT_NAME || 'Percy Appium App Advanced (wd)',
-    buildName: process.env.BROWSERSTACK_BUILD_NAME || 'App Percy Advanced wd Android',
+    buildName: process.env.BROWSERSTACK_BUILD_NAME || `App Percy Advanced wd ${isIOS ? 'iOS' : 'Android'}`,
   },
   percyOptions: { enabled: true, ignoreErrors: true },
   app: process.env.APP,
-  device: process.env.DEVICE || 'Google Pixel 6',
-  os_version: process.env.OS_VERSION || '12',
+  device: process.env.DEVICE || (isIOS ? 'iPhone 15' : 'Google Pixel 6'),
+  os_version: process.env.OS_VERSION || (isIOS ? '17' : '12'),
   project: 'First Node App Percy Project',
   build: 'App Percy Advanced wd',
   name: 'advanced_visual_test',

--- a/webdriverio/advanced/advanced.conf.js
+++ b/webdriverio/advanced/advanced.conf.js
@@ -3,6 +3,11 @@
 // AA_USERNAME, AA_ACCESS_KEY, APP env vars). The single spec exercises
 // every applicable matrix row via per-screenshot options.
 
+// PLATFORM selects the device/os defaults (android | ios). The CI workflow
+// sets it and supplies the matching APP (Android: APP_BS_URL, iOS:
+// APP_BS_URL_IOS). DEVICE / OS_VERSION env vars still override per-run.
+const isIOS = (process.env.PLATFORM || 'android').toLowerCase() === 'ios'
+
 exports.config = {
   user: process.env.AA_USERNAME || 'BROWSERSTACK_USERNAME',
   key: process.env.AA_ACCESS_KEY || 'BROWSERSTACK_ACCESS_KEY',
@@ -14,10 +19,10 @@ exports.config = {
   capabilities: [
     {
       project: process.env.BROWSERSTACK_PROJECT_NAME || 'Percy Appium App Advanced Example',
-      build: process.env.BROWSERSTACK_BUILD_NAME || 'App Percy Advanced Wdio Android',
+      build: process.env.BROWSERSTACK_BUILD_NAME || `App Percy Advanced Wdio ${isIOS ? 'iOS' : 'Android'}`,
       name: 'advanced_visual_test',
-      device: process.env.DEVICE || 'Google Pixel 6',
-      os_version: process.env.OS_VERSION || '12.0',
+      device: process.env.DEVICE || (isIOS ? 'iPhone 15' : 'Google Pixel 6'),
+      os_version: process.env.OS_VERSION || (isIOS ? '17' : '12.0'),
       app: process.env.APP || 'bs://<hashed app-id>',
     },
   ],


### PR DESCRIPTION
Stacked on #17. Adds an **iOS run path** to the advanced App Percy example — **CI scaffolding only**, Android behavior unchanged.

## What
- **`.github/workflows/advanced.yml`**: new `platform` (`android`|`ios`) `workflow_dispatch` input. Picks the right App Automate app per platform — `APP_BS_URL` (android) / **`APP_BS_URL_IOS`** (ios) — passes `PLATFORM` through to the run, and the secret sanity-check is platform-aware (names the missing secret per platform).
- **`webdriverio/advanced/advanced.conf.js`** and **`wd/advanced/advanced.js`**: `PLATFORM`-aware device/os defaults — iOS → `iPhone 15 / 17`, Android unchanged → `Google Pixel 6 / 12`. `DEVICE`/`OS_VERSION` still override per-run.

## Backward compatibility
Default `platform` is `android`; with `PLATFORM` unset the configs resolve to the exact same Android caps as before. No change to existing Android runs.

## ⚠️ Scope — scaffolding, not full iOS coverage
The advanced spec's element/region rows use **Android-specific locators** (e.g. `//*[@resource-id="org.wikipedia.alpha:id/search_container"]`, `~Search Wikipedia`) against the **Wikipedia Android app**, plus Pixel-6 scroll offsets. So an iOS run with the *current* spec only makes sense for the non-element rows. Full iOS coverage needs an **iOS app build** + **iOS element locators** (and the App Automate iOS environment confirmed working) — tracked as a follow-up. This PR just wires the build path so iOS can be run once those exist.

## New secret required for iOS runs
`APP_BS_URL_IOS` (App Automate `bs://` URL of the iOS app build).

Part of PER-8195.

🤖 Generated with [Claude Code](https://claude.com/claude-code)